### PR TITLE
Fix building docs locally

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+MaterialModels = "d7e62f90-dad9-4fee-a9a8-264218a34fd2"
 
 [compat]
 Documenter = "0.26"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 MaterialModels = "d7e62f90-dad9-4fee-a9a8-264218a34fd2"
+
+[compat]
+Documenter = "0.26"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 MaterialModels = "d7e62f90-dad9-4fee-a9a8-264218a34fd2"
-
-[compat]
-Documenter = "0.26"


### PR DESCRIPTION
Following [discourse](https://discourse.julialang.org/t/psa-use-a-project-for-building-your-docs/14974) I ran
`julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'` [1]
This adds `MaterialModels` to the `docs/Project.toml`. Then, running 
`julia --project=docs/ docs/make.jl` [2]
builds the documentation locally just fine.

So I guess [1] is only required the first time to generate the Manifest (and download packages if required) and [2] each time one wants to build the docs?


~~We could also include a compat section for documenter as in Fredrik's post above I guess...~~
(Sorry about the back and forth, did not realize [compat] was already there from before...)
