### PR TITLE
Refactor cache

### DIFF
--- a/src/MaterialModels.jl
+++ b/src/MaterialModels.jl
@@ -34,6 +34,12 @@ Defines the type of strain measure the a material uses, i.e Deformation gradient
 abstract type StrainMeasure end
 
 """
+    AbstractCache
+Stores matrices, vectors etc. to avoid re-allcating memory each time the material routine is called.
+"""
+abstract type AbstractCache end
+
+"""
     material_response(m::AbstractMaterial, Δε::SymmetricTensor{2,3}, state::AbstractMaterialState, Δt; cache, options)
 
 Compute the stress, stress tangent and state variables for the given strain increment `Δε` and previous state `state`.
@@ -74,6 +80,9 @@ Update the cache object with the residual function for the current time/load ste
 As the residual functions depend i.a. on the strain increment, the function and its jacobian need to be updated for every load step.
 """
 function update_cache! end
+
+struct DefaultCache <: AbstractCache end
+get_cache(::AbstractMaterial) = DefaultCache() #Fallback for materials that does need to allocate.
 
 include("traits.jl")
 include("LinearElastic.jl")

--- a/src/MaterialModels.jl
+++ b/src/MaterialModels.jl
@@ -38,6 +38,7 @@ abstract type StrainMeasure end
 Stores matrices, vectors etc. to avoid re-allcating memory each time the material routine is called.
 """
 abstract type AbstractCache end
+struct DefaultCache <: AbstractCache end
 
 """
     material_response(m::AbstractMaterial, Δε::SymmetricTensor{2,3}, state::AbstractMaterialState, Δt; cache, options)
@@ -70,7 +71,7 @@ When multithreading is used, each threads needs its own cache.
 Returns `nothing` for materials that don't need a cache.
 """
 function get_cache(::AbstractMaterial)
-    return nothing
+    DefaultCache() 
 end
 """
     update_cache!(cache::OnceDifferentiable, f)
@@ -80,9 +81,6 @@ Update the cache object with the residual function for the current time/load ste
 As the residual functions depend i.a. on the strain increment, the function and its jacobian need to be updated for every load step.
 """
 function update_cache! end
-
-struct DefaultCache <: AbstractCache end
-get_cache(::AbstractMaterial) = DefaultCache() #Fallback for materials that does need to allocate.
 
 include("traits.jl")
 include("LinearElastic.jl")

--- a/src/MaterialModels.jl
+++ b/src/MaterialModels.jl
@@ -38,7 +38,6 @@ abstract type StrainMeasure end
 Stores matrices, vectors etc. to avoid re-allcating memory each time the material routine is called.
 """
 abstract type AbstractCache end
-struct DefaultCache <: AbstractCache end
 
 """
     material_response(m::AbstractMaterial, Δε::SymmetricTensor{2,3}, state::AbstractMaterialState, Δt; cache, options)
@@ -71,7 +70,7 @@ When multithreading is used, each threads needs its own cache.
 Returns `nothing` for materials that don't need a cache.
 """
 function get_cache(::AbstractMaterial)
-    DefaultCache() 
+    nothing 
 end
 """
     update_cache!(cache::OnceDifferentiable, f)

--- a/src/Plastic.jl
+++ b/src/Plastic.jl
@@ -48,6 +48,10 @@ end
 Base.zero(::Type{PlasticState{dim,T,M}}) where {dim,T,M} = PlasticState(zero(SymmetricTensor{2,dim,T,M}), zero(T), zero(SymmetricTensor{2,dim,T,M}), zero(T))
 initial_material_state(::Plastic) = zero(PlasticState{3,Float64,6})
 
+struct PlasticCache{T<:OnceDifferentiable} <: AbstractCache
+    nlsolve_cache::T
+end
+
 function get_cache(m::Plastic)
     state = initial_material_state(m)
     # it doesn't actually matter which state and strain step we use here,
@@ -55,7 +59,7 @@ function get_cache(m::Plastic)
     f(r_vector, x_vector) = vector_residual!(((x)->MaterialModels.residuals(x, m, state, zero(SymmetricTensor{2,3}))), r_vector, x_vector, m)
     v_cache = Vector{Float64}(undef, get_n_scalar_equations(m))
     cache = NLsolve.OnceDifferentiable(f, v_cache, v_cache; autodiff = :forward)
-    return cache
+    return PlasticCache(cache)
 end
 
 # constitutive driver operates in 3D, so these can always be 3D
@@ -122,6 +126,8 @@ See [NLsolve documentation](https://github.com/JuliaNLSolvers/NLsolve.jl#common-
 function material_response(m::Plastic, ε::SymmetricTensor{2,3,T,6}, state::PlasticState{3},
     Δt=nothing; cache=get_cache(m), options::Dict{Symbol, Any} = Dict{Symbol, Any}()) where T
 
+    nlsolve_cache = cache.nlsolve_cache
+
     σ_trial = m.Eᵉ ⊡ (ε - state.εᵖ)
     Φ = sqrt(3/2)*norm(dev(σ_trial-state.α)) - m.σ_y - state.κ
 
@@ -129,21 +135,21 @@ function material_response(m::Plastic, ε::SymmetricTensor{2,3,T,6}, state::Plas
         return σ_trial, m.Eᵉ, state
     else
         # set the current residual function that depends only on the variables
-        # cache.f = (r_vector, x_vector) -> vector_residual!(((x)->residuals(x,m,state,Δε)), r_vector, x_vector, m)
+        # nlsolve_cache.f = (r_vector, x_vector) -> vector_residual!(((x)->residuals(x,m,state,Δε)), r_vector, x_vector, m)
         f(r_vector, x_vector) = vector_residual!(((x)->residuals(x,m,state,ε)), r_vector, x_vector, m)
-        update_cache!(cache, f)
+        update_cache!(nlsolve_cache, f)
         # initial guess
         x0 = ResidualsPlastic(σ_trial, state.κ, state.α, state.μ)
         # convert initial guess to vector
-        tomandel!(cache.x_f, x0)
+        tomandel!(nlsolve_cache.x_f, x0)
         # solve for variables x
         nlsolve_options = get(options, :nlsolve_params, Dict{Symbol, Any}(:method=>:newton))
         haskey(nlsolve_options, :method) || merge!(nlsolve_options, Dict{Symbol, Any}(:method=>:newton)) # set newton if the user did not supply another method
-        result = NLsolve.nlsolve(cache, cache.x_f; nlsolve_options...)
+        result = NLsolve.nlsolve(nlsolve_cache, nlsolve_cache.x_f; nlsolve_options...)
         if result.f_converged
             x = frommandel(ResidualsPlastic, result.zero::Vector{T})
             εᵖ = state.εᵖ + x.μ*(3/(2*sqrt(3/2)*norm(dev(x.σ-x.α)))*dev(x.σ-x.α))
-            dRdx = cache.DF
+            dRdx = nlsolve_cache.DF
             inv_J_σσ = frommandel(SymmetricTensor{4,3}, inv(dRdx))
             ∂σ∂ε = inv_J_σσ ⊡ m.Eᵉ
             return x.σ, ∂σ∂ε, PlasticState(εᵖ, x.κ, x.α, x.μ)

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -28,7 +28,7 @@ function material_response(
     Δε::AbstractTensor{2,d,T},
     state::AbstractMaterialState,
     Δt = nothing;
-    cache = nothing,
+    cache = get_cache(m),
     options = Dict{Symbol, Any}(),
     ) where {d,T}
 

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -45,7 +45,7 @@ function material_response(
     Δε::AbstractTensor{2,d,T},
     state::AbstractMaterialState,
     Δt = nothing;
-    cache::Union{Any, Nothing} = nothing, #get_cache(m), #TODO: create AbstractCache type
+    cache =  get_cache(m),
     options = Dict{Symbol, Any}(),
     ) where {d, T}
     


### PR DESCRIPTION
This is how I think material cache should be implemented.
I once implemented a material that needed to store 2 vectors, and I think the current implementation of caches does to allow for that...

So now each material that needs cache, can wrap their vectors etc in their own type.

I had to refactor the planestress-wrapper aswell.