### PR TITLE
Static arrays in plane stress iterations

### DIFF
--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -51,7 +51,6 @@ function material_response(
     
     tol = get(options, :plane_stress_tol, 1e-8)
     max_iter = get(options, :plane_stress_max_iter, 10)
-    converged = false
 
     Δε_3D = increase_dim(Δε)
     
@@ -62,7 +61,6 @@ function material_response(
         σ, ∂σ∂ε, temp_state = material_response(m, Δε_3D, state, Δt; cache=cache, options=options)
         σ_mandel = _tomandel_sarray(dim, σ)
         if norm(σ_mandel) < tol
-            converged = true
             ∂σ∂ε_2D = fromvoigt(SymmetricTensor{4,d}, inv(inv(tovoigt(∂σ∂ε))[nonzero_idxs, nonzero_idxs]))
             return reduce_dim(σ, dim), ∂σ∂ε_2D, temp_state
         end
@@ -81,7 +79,7 @@ function testaa()
 
     ε = rand(SymmetricTensor{2,1})
 
-    @code_warntype material_response(UniaxialStress(), m, ε, state)
+    @time material_response(UniaxialStress(), m, ε, state)
 end
 
 function _tomandel_sarray(::PlaneStress, A::SymmetricTensor{2, 3}) 

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -58,26 +58,51 @@ function material_response(
     zero_idxs = get_zero_indices(dim, Δε_3D)
     nonzero_idxs = get_nonzero_indices(dim, Δε_3D)
     
-    Δε_voigt = cache.x_f
+    Δε_voigt = zeros(Float64, 6)
     fill!(Δε_voigt, 0.0)
-    σ_mandel = cache.F
-    J = cache.DF
+    #σ_mandel = cache.F
+    #J = cache.DF
     
     for _ in 1:max_iter
         σ, ∂σ∂ε, temp_state = material_response(m, Δε_3D, state, Δt; cache=cache, options=options)
-        tomandel!(σ_mandel, σ)
+        σ_mandel = tomandel2(dim, σ)
         if norm(view(σ_mandel, zero_idxs)) < tol
             converged = true
             ∂σ∂ε_2D = fromvoigt(SymmetricTensor{4,d}, inv(inv(tovoigt(∂σ∂ε))[nonzero_idxs, nonzero_idxs]))
             return reduce_dim(σ, dim), ∂σ∂ε_2D, temp_state
         end
-        tomandel!(J, ∂σ∂ε)
+        J = tomandel2(∂σ∂ε)
         fill!(Δε_voigt, 0.0)
-        Δε_voigt[zero_idxs] = -view(J, zero_idxs, zero_idxs) \ view(σ_mandel, zero_idxs)
+        Δε_temp = -view(J, zero_idxs, zero_idxs) \ view(σ_mandel, zero_idxs)
+        @show  typeof(Δε_temp)
+        Δε_voigt[zero_idxs] = Δε_temp
         Δε_correction = frommandel(SymmetricTensor{2,3}, Δε_voigt)
         Δε_3D = Δε_3D + Δε_correction
     end
     error("Not converged. Could not find plane stress state.")
+end
+
+function testaa()
+    m = LinearElastic(E=200e3, ν=0.3)
+
+    state = initial_material_state(m)
+
+    ε = rand(SymmetricTensor{2,2})
+
+    a,b,c = material_response(PlaneStress(), m, ε, state)
+end
+
+function tomandel2(dim::PlaneStress, A::SymmetricTensor{2, 3}) 
+    @SVector [A[1,1], A[2,2], A[3,3], √2A[2,3], √2A[1,3], √2A[1,2]]
+end
+
+function tomandel2(A::SymmetricTensor{4, 3}) 
+    @SMatrix [A[1,1,1,1] A[1,1,2,2] A[1,1,3,3] √2*A[1,1,2,3] √2*A[1,1,1,3] √2*A[1,1,1,2]; 
+              A[2,2,1,1] A[2,2,2,2] A[2,2,3,3] √2*A[2,2,2,3] √2*A[2,2,1,3] √2*A[2,2,1,2];
+              A[3,3,1,1] A[3,3,2,2] A[3,3,3,3] √2*A[3,3,2,3] √2*A[3,3,1,3] √2*A[3,3,1,2];
+              √2*A[2,3,1,1] √2*A[2,3,2,2] √2*A[2,3,3,3] 2*A[2,3,2,3] 2*A[2,3,1,3] 2*A[2,3,1,2];
+              √2*A[1,3,1,1] √2*A[1,3,2,2] √2*A[1,3,3,3] 2*A[1,3,2,3] 2*A[1,3,1,3] 2*A[1,3,1,2];
+              √2*A[1,2,1,1] √2*A[1,2,2,2] √2*A[1,2,3,3] 2*A[1,2,2,3] 2*A[1,2,1,3] 2*A[1,2,1,2]]
 end
 
 # out of plane / axis components for restricted stress cases


### PR DESCRIPTION
I played around a bit with static arrays in plane-stress iterations...seems to not allocate anythihng.
