### PR TITLE
redesign of strain trait system

### DIFF
--- a/src/FiniteStrain/neohook.jl
+++ b/src/FiniteStrain/neohook.jl
@@ -24,7 +24,7 @@ function NeoHook(; λ::T, μ::T) where T
     return NeoHook(λ, μ)
 end
 
-strainmeasure(::NeoHook) = RightCauchyGreen()
+native_tangent_type(::Type{NeoHook}) = ∂S∂C
 
 function elastic_strain_energy_density(mp::NeoHook, C::SymmetricTensor{2,3})
     J = sqrt(det(C))

--- a/src/FiniteStrain/stvenant.jl
+++ b/src/FiniteStrain/stvenant.jl
@@ -23,7 +23,7 @@ function StVenant(; λ::T, μ::T) where T
     return StVenant(λ, μ)
 end
 
-strainmeasure(::StVenant) = RightCauchyGreen()
+native_tangent_type(::Type{StVenant}) = ∂S∂C
 
 function elastic_strain_energy_density(mp::StVenant, C)
     (; μ, λ) = mp
@@ -46,5 +46,3 @@ function material_response(mp::StVenant, C::SymmetricTensor{2,3}, state::StVenan
 
     return S, ∂S∂C, StVenantState()
 end
-
-

--- a/src/FiniteStrain/yeoh.jl
+++ b/src/FiniteStrain/yeoh.jl
@@ -26,7 +26,7 @@ function Yeoh(; λ::T, μ::T, c₂::T, c₃::T) where T <: AbstractFloat
     return Yeoh(λ, μ, c₂, c₃)
 end
 
-strainmeasure(::Yeoh) = RightCauchyGreen()
+native_tangent_type(::Type{Yeoh}) = ∂S∂C
 
 function elastic_strain_energy_density(mp::Yeoh, C::SymmetricTensor{2,3})
     J = sqrt(det(C))

--- a/src/LinearElastic.jl
+++ b/src/LinearElastic.jl
@@ -21,6 +21,9 @@ end
 # Let's always supply a constructor with keyword arguments
 LinearElastic(;E::Float64, ν::Float64) = LinearElastic(E, ν)
 
+# compatibility with large strain framework
+native_tangent_type(::Type{LinearElastic}) = ∂σ∂ε
+
 function elastic_tangent_3D(E::T, ν::T) where T
     λ = E*ν / ((1 + ν) * (1 - 2ν))
     μ = E / (2(1 + ν))

--- a/src/MaterialModels.jl
+++ b/src/MaterialModels.jl
@@ -104,6 +104,7 @@ export LinearElastic, Plastic, CrystalViscoPlastic
 export LinearElasticState, PlasticState, CrystalViscoPlasticState
 export AbstractDim, UniaxialStrain, UniaxialStress, PlaneStrain, PlaneStress
 
+export DeformationGradient, RightCauchyGreen, GreenLagrange, SmallStrain
 export NeoHook, Yeoh, StVenant
 
 export XuNeedleman

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -99,21 +99,6 @@ function material_response(
     return out_stress.value, out_tangent.value, newstate
 end
 
-# TODO: needed?
-# allow call with tensor valued deformation gradient as default
-function material_response(
-        ::Type{output_tangent},
-        m::AbstractMaterial,
-        F::Tensor{2}, # by default this is a deformation gradient
-        state,
-        Δt::Float64 = 0.0;
-        cache=nothing,
-        options=nothing,
-    ) where {output_tangent}
-    material_response(output_tangent, m, DeformationGradient(F), state, Δt; cache, options)
-end
-
-
 # wrapped stress + tangent types for tangent transformation
 function _material_response( # internal as it returns typed stress/tangent
         m::M,
@@ -137,6 +122,11 @@ function _material_response( # internal as it returns typed stress/tangent
     return stress_type(stress), tangent_type(tangent), new_state
 end
     
+# transformation for strain energy
+function elastic_strain_energy_density(material::M, strain::StrainMeasure) where M
+    native_strain = transform_strain(strain, native_strain_type(M))
+    return elastic_strain_energy_density(material, native_strain.value)
+end
 
 native_strain_type(::Type{M}) where M<:AbstractMaterial = _strain_type(native_tangent_type(M))
 native_stress_type(::Type{M}) where M<:AbstractMaterial = _stress_type(native_tangent_type(M))

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -1,62 +1,146 @@
 
-struct GreenLagrange <: StrainMeasure end
-struct RightCauchyGreen <: StrainMeasure end
-struct DeformationGradient <: StrainMeasure end
-struct VelocityGradient <: StrainMeasure end
+struct GreenLagrange{T<:SymmetricTensor{2}} <: StrainMeasure; value::T; end
+struct RightCauchyGreen{T<:SymmetricTensor{2}} <: StrainMeasure; value::T; end
+struct DeformationGradient{T<:Tensor{2}} <: StrainMeasure; value::T; end
+struct VelocityGradient{T} <: StrainMeasure; value::T; end
 
 strainmeasure(m::AbstractMaterial) = error("Strain measure for material $m not defined ")
 
+abstract type StressMeasure end
+struct SecondPiolaKirchhoff{T<:SymmetricTensor{2}} <: StressMeasure; value::T; end
+struct FirstPiolaKirchhoff{T<:Tensor{2}} <: StressMeasure; value::T; end
+struct FirstPiolaKirchhoffTransposed{T<:Tensor{2}} <: StressMeasure; value::T; end
+
 abstract type AbstractTangent end
-struct ∂S∂C <: AbstractTangent end
-struct ∂S∂E <: AbstractTangent end
-struct ∂Pᵀ∂F <: AbstractTangent end
-
-#Here we must associate a strain meassure with an output tangent
-# These default makes sence: 
-default_tangent(::GreenLagrange) = ∂S∂E()
-default_tangent(::RightCauchyGreen) = ∂S∂C()
-default_tangent(::DeformationGradient) = ∂Pᵀ∂F()
+struct ∂S∂C{T<:SymmetricTensor{4}} <: AbstractTangent; value::T; end
+struct ∂S∂E{T<:SymmetricTensor{4}} <: AbstractTangent; value::T; end
+struct ∂Pᵀ∂F{T<:Tensor{4}} <: AbstractTangent; value::T; end
 
 """
-    compute_strain(F::Tensor{2}, stype::StrainMeasure)
+    transform_strain(strain::::StrainMeasure, to::Type{StrainMeasure})
 
-Compute strain meassure defined by `stype`, using the deformation gradient `F`
+Compute strain meassure defined by `to` from `strain`.
 """
-compute_strain(F::Tensor{2}, ::RightCauchyGreen) = tdot(F)
-compute_strain(F::Tensor{2}, ::GreenLagrange) = symmetric(1/2 * (F' ⋅ F - one(F)))
-compute_strain(F::Tensor{2}, ::DeformationGradient) = F
-
-"""
-    transform_tangent(stress, tangent, F::Tensor{2}, from::AbstractTangent, to::AbstractTangent)
-
-Transform the stress and tangent
-"""
-transform_tangent(S , dSdC,  F::Tensor{2}, from::∂S∂C, to::∂S∂C) = S, dSdC
-transform_tangent(Pᵀ, ∂Pᵀ∂F, F::Tensor{2}, from::∂Pᵀ∂F, to::∂Pᵀ∂F) = Pᵀ, ∂Pᵀ∂F
-transform_tangent(S , ∂S∂E,  F::Tensor{2}, from::∂S∂E, to::∂S∂E) = S, ∂S∂E
-
-transform_tangent(S, dSdC, F::Tensor{2}, from::∂S∂C, to::∂S∂E) = S, 2dSdC
-transform_tangent(S, dSdC, F::Tensor{2,3,T}, from::∂S∂C, to::∂Pᵀ∂F) where T = begin 
-    I = one(SymmetricTensor{2,3,T})
-    Pᵀ = S⋅F'
-    dPᵀdF = otimesl(S, I) + otimesu(I, F) ⊡ dSdC ⊡ (otimesl(I, F') + otimesu(F', I))
-    return Pᵀ, dPᵀdF
+transform_strain(strain::Ts, ::Type{Tn}) where {Tn, Ts<:Tn} = strain # generic (no transformation)
+function transform_strain(F::DeformationGradient, ::Type{RightCauchyGreen}) 
+    C = tdot(F.value)
+    return RightCauchyGreen(C)
 end
-#...
+function transform_strain(C::RightCauchyGreen{T}, ::Type{GreenLagrange}) where T
+    E = (C.value - one(T))/2
+    return GreenLagrange(E)
+end
+function transform_strain(E::GreenLagrange{T}, ::Type{RightCauchyGreen}) where T
+    C = 2E.value + one(T)
+    return RightCauchyGreen(C)
+end
+function transform_strain(F::DeformationGradient, ::GreenLagrange)
+    C = tdot(F.value)
+    E = (C - one(C))/2
+    return GreenLagrange(E)
+end
 
 """
-    material_response(output_tangent::AbstractTangent, m::AbstractMaterial, F::Tensor{2}, state::AbstractMaterialState, Δt::Float64; cache, options)
+    transform_tangent(stress::StressMeasure, tangent::AbstractTangent, to::Type{AbstractTangent}, strain::StrainMeasure)
+
+Transform the stress and tangent to the stress and tangent types given by the tangent type `to`.
+Some transformations require the deformation gradient which can be given by `strain`.
+Transformations that do not require the deformation gradient ignore `strain`.
+"""
+transform_stress_tangent(stress, tangent::T, ::Type{T}, ::StrainMeasure)  where T<:AbstractTangent = stress, tangent
+function transform_stress_tangent(S::SecondPiolaKirchhoff, dSdC::∂S∂C, ::Type{∂S∂E}, ::StrainMeasure)
+    return S, ∂S∂E(2dSdC.value)
+end
+function transform_stress_tangent(S::SecondPiolaKirchhoff, dSdE::∂S∂E, ::Type{∂S∂C}, ::StrainMeasure)
+    return S, ∂S∂C(0.5dSdE.value)
+end
+function transform_stress_tangent(
+        S::SecondPiolaKirchhoff{T},
+        dSdC::∂S∂C, 
+        ::Type{∂Pᵀ∂F},
+        F::DeformationGradient
+) where T
+    I = one(T)
+    Pᵀ = S.value ⋅ F.value'
+    dPᵀdF = otimesl(S.value, I) + otimesu(I, F.value) ⊡ dSdC.value ⊡ (otimesl(I, F.value') + otimesu(F.value', I))
+    return FirstPiolaKirchhoff(Pᵀ), ∂Pᵀ∂F(dPᵀdF)
+end
+
+"""
+    material_response(output_tangent::Type{<:AbstractTangent}, m::AbstractMaterial, strain::StrainMeasure, state, Δt::Float64; cache, options)
 
 Function for automatically converting the output stress and tangent from any material, to any 
 other stress/tangent defined by `output_tangent` (dSdC, dPᵀdF etc.) 
+
+!!! note
+    Not all stress/strain measures are readily convertible into each other without additional input. 
+    E.g. `∂S∂C` and `∂S∂E` can be easily converted without extra inputs, but the conversion
+    of `∂S∂C` into `∂Pᵀ∂F` requires the deformation gradient `F` as `input_strain`.
 """
+# tangent transformation layer
+function material_response(
+        ::Type{output_tangent},
+        m::M,
+        strain::StrainMeasure, # usually DeformationGradient(F)
+        state,
+        Δt::Float64 = 0.0;
+        cache=nothing,
+        options=nothing,
+    ) where {M<:AbstractMaterial, output_tangent}
 
-function material_response(output_tangent::AbstractTangent, m::AbstractMaterial, F::Tensor{2}, state::AbstractMaterialState, Δt::Float64 = 0.0; cache=nothing, options=nothing)
-    straintype = strainmeasure(m);
+    native_strain = transform_strain(strain, native_strain_type(M))
+    stress, tangent, newstate = _material_response(m, native_strain, state, Δt; cache=cache, options=options)
+    out_stress, out_tangent = transform_stress_tangent(stress, tangent, output_tangent, strain)
 
-    strain = compute_strain(F, straintype)
-    stress, strain, newstate = material_response(m, strain, state, Δt, cache=cache, options=options)
-    out_stress, out_tangent = transform_tangent(stress, strain, F, default_tangent(straintype), output_tangent)
-
-    return out_stress, out_tangent, newstate
+    # return tensors (not wrapped stress types)
+    return out_stress.value, out_tangent.value, newstate
 end
+
+# TODO: needed?
+# allow call with tensor valued deformation gradient as default
+function material_response(
+        ::Type{output_tangent},
+        m::AbstractMaterial,
+        F::Tensor{2}, # by default this is a deformation gradient
+        state,
+        Δt::Float64 = 0.0;
+        cache=nothing,
+        options=nothing,
+    ) where {output_tangent}
+    material_response(output_tangent, m, DeformationGradient(F), state, Δt; cache, options)
+end
+
+
+# wrapped stress + tangent types for tangent transformation
+function _material_response( # internal as it returns typed stress/tangent
+        m::M,
+        strain::T,
+        state,
+        Δt::Float64 = 0.0;
+        cache=nothing,
+        options=nothing
+    ) where {M<:AbstractMaterial, T<:StrainMeasure}
+
+    # TODO: Maybe this check is not needed if this routine is only called from the tangent transformation layer
+    compatible_strain_measure(T, native_strain_type(M)) || error("$T is not the native strain measure for $M:")
+
+    # call of native 3D routine
+    stress, tangent, new_state = material_response(m, strain.value, state, Δt; cache, options)
+
+    tangent_type = native_tangent_type(M)
+    stress_type = _stress_type(tangent_type)
+
+    # return wrapped stress/tangent types for tangent transformations
+    return stress_type(stress), tangent_type(tangent), new_state
+end
+    
+
+native_strain_type(::Type{M}) where M<:AbstractMaterial = _strain_type(native_tangent_type(M))
+native_stress_type(::Type{M}) where M<:AbstractMaterial = _stress_type(native_tangent_type(M))
+_strain_type(::Type{∂S∂C}) = RightCauchyGreen
+_stress_type(::Type{∂S∂C}) = SecondPiolaKirchhoff
+
+# same strain type is compatible
+compatible_strain_measure(::Type{<:T}, ::Type{T}) where T = true
+# different strain type is not compatible
+compatible_strain_measure(::Type{<:T1}, ::Type{T2}) where {T1, T2} = false

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -37,7 +37,7 @@ function transform_strain(E::GreenLagrange{T}, ::Type{RightCauchyGreen}) where T
     C = 2E.value + one(T)
     return RightCauchyGreen(C)
 end
-function transform_strain(F::DeformationGradient, ::GreenLagrange)
+function transform_strain(F::DeformationGradient, ::Type{GreenLagrange})
     C = tdot(F.value)
     E = (C - one(C))/2
     return GreenLagrange(E)

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -3,6 +3,7 @@ struct GreenLagrange{T<:SymmetricTensor{2}} <: StrainMeasure; value::T; end
 struct RightCauchyGreen{T<:SymmetricTensor{2}} <: StrainMeasure; value::T; end
 struct DeformationGradient{T<:Tensor{2}} <: StrainMeasure; value::T; end
 struct VelocityGradient{T} <: StrainMeasure; value::T; end
+struct SmallStrain{T} <: StrainMeasure; value::T;  end
 
 strainmeasure(m::AbstractMaterial) = error("Strain measure for material $m not defined ")
 
@@ -10,11 +11,13 @@ abstract type StressMeasure end
 struct SecondPiolaKirchhoff{T<:SymmetricTensor{2}} <: StressMeasure; value::T; end
 struct FirstPiolaKirchhoff{T<:Tensor{2}} <: StressMeasure; value::T; end
 struct FirstPiolaKirchhoffTransposed{T<:Tensor{2}} <: StressMeasure; value::T; end
+struct TrueStress{T<:SymmetricTensor{2}} <: StressMeasure; value::T; end
 
 abstract type AbstractTangent end
 struct ∂S∂C{T<:SymmetricTensor{4}} <: AbstractTangent; value::T; end
 struct ∂S∂E{T<:SymmetricTensor{4}} <: AbstractTangent; value::T; end
 struct ∂Pᵀ∂F{T<:Tensor{4}} <: AbstractTangent; value::T; end
+struct ∂σ∂ε{T<:SymmetricTensor{4}} <: AbstractTangent; value::T; end
 
 """
     transform_strain(strain::::StrainMeasure, to::Type{StrainMeasure})
@@ -139,6 +142,8 @@ native_strain_type(::Type{M}) where M<:AbstractMaterial = _strain_type(native_ta
 native_stress_type(::Type{M}) where M<:AbstractMaterial = _stress_type(native_tangent_type(M))
 _strain_type(::Type{∂S∂C}) = RightCauchyGreen
 _stress_type(::Type{∂S∂C}) = SecondPiolaKirchhoff
+_strain_type(::Type{∂σ∂ε}) = SmallStrain
+_stress_type(::Type{∂σ∂ε}) = TrueStress
 
 # same strain type is compatible
 compatible_strain_measure(::Type{<:T}, ::Type{T}) where T = true

--- a/test/test_linear_elastic.jl
+++ b/test/test_linear_elastic.jl
@@ -15,6 +15,9 @@
     @test σ == m.Eᵉ ⊡ ε
     @test ∂σ∂ε == m.Eᵉ
 
+    # stress/ strain measures for compatibility with finite strain system
+    @test MaterialModels.native_strain_type(LinearElastic) == SmallStrain
+    @test MaterialModels.native_stress_type(LinearElastic) == MaterialModels.TrueStress
 end
 
 function get_LinearElastic_loading()

--- a/test/test_neohook.jl
+++ b/test/test_neohook.jl
@@ -21,4 +21,8 @@
 
     dSdC_autodiff = gradient(C->material_response(m, C)[1], C)
     @test dSdC_autodiff ≈ dSdC
+
+    # stress/ strain measures
+    @test MaterialModels.native_strain_type(NeoHook) == RightCauchyGreen
+    @test MaterialModels.native_stress_type(NeoHook) == MaterialModels.SecondPiolaKirchhoff
 end

--- a/test/test_straintraits.jl
+++ b/test/test_straintraits.jl
@@ -21,12 +21,12 @@
     _C = MaterialModels.transform_strain(RightCauchyGreen(C), RightCauchyGreen)
     @test _C.value === C
 
-    S, dSdC, state = material_response(MaterialModels.∂S∂C, mat, DeformationGradient(F), state, Δt)
+    S, dSdC, state = material_response(MaterialModels.∂S∂C(), mat, DeformationGradient(F), state, Δt)
 
-    Pᵀ, dPᵀdF, state = material_response(MaterialModels.∂Pᵀ∂F, mat, DeformationGradient(F), state, Δt)
+    Pᵀ, dPᵀdF, state = material_response(MaterialModels.∂Pᵀ∂F(), mat, DeformationGradient(F), state, Δt)
     @test Pᵀ == S⋅F'
 
-    S_E, dSdE, state = material_response(MaterialModels.∂S∂E, mat, DeformationGradient(F), state, Δt)
+    S_E, dSdE, state = material_response(MaterialModels.∂S∂E(), mat, DeformationGradient(F), state, Δt)
     @test S_E == S
     @test 2dSdC == dSdE
 

--- a/test/test_straintraits.jl
+++ b/test/test_straintraits.jl
@@ -8,6 +8,19 @@
     C = tdot(F)
     E = (C - one(C))/2
 
+    # strain transformations
+    _E = MaterialModels.transform_strain(RightCauchyGreen(C), GreenLagrange)
+    @test E ≈ _E.value
+    _E = MaterialModels.transform_strain(DeformationGradient(F), GreenLagrange)
+    @test E ≈ _E.value
+    _C = MaterialModels.transform_strain(GreenLagrange(E), RightCauchyGreen)
+    @test C ≈ _C.value
+    _C = MaterialModels.transform_strain(DeformationGradient(F), RightCauchyGreen)
+    @test C ≈ _C.value
+    # no transformation
+    _C = MaterialModels.transform_strain(RightCauchyGreen(C), RightCauchyGreen)
+    @test _C.value === C
+
     S, dSdC, state = material_response(MaterialModels.∂S∂C, mat, F, state, Δt)
 
     Pᵀ, dPᵀdF, state = material_response(MaterialModels.∂Pᵀ∂F, mat, F, state, Δt)

--- a/test/test_straintraits.jl
+++ b/test/test_straintraits.jl
@@ -21,12 +21,12 @@
     _C = MaterialModels.transform_strain(RightCauchyGreen(C), RightCauchyGreen)
     @test _C.value === C
 
-    S, dSdC, state = material_response(MaterialModels.∂S∂C, mat, F, state, Δt)
+    S, dSdC, state = material_response(MaterialModels.∂S∂C, mat, DeformationGradient(F), state, Δt)
 
-    Pᵀ, dPᵀdF, state = material_response(MaterialModels.∂Pᵀ∂F, mat, F, state, Δt)
+    Pᵀ, dPᵀdF, state = material_response(MaterialModels.∂Pᵀ∂F, mat, DeformationGradient(F), state, Δt)
     @test Pᵀ == S⋅F'
 
-    S_E, dSdE, state = material_response(MaterialModels.∂S∂E, mat, F, state, Δt)
+    S_E, dSdE, state = material_response(MaterialModels.∂S∂E, mat, DeformationGradient(F), state, Δt)
     @test S_E == S
     @test 2dSdC == dSdE
 

--- a/test/test_straintraits.jl
+++ b/test/test_straintraits.jl
@@ -8,12 +8,12 @@
     C = tdot(F)
     E = (C - one(C))/2
 
-    S, dSdC, state = material_response(MaterialModels.∂S∂C(), mat, F, state, Δt)
+    S, dSdC, state = material_response(MaterialModels.∂S∂C, mat, F, state, Δt)
 
-    Pᵀ, dPᵀdF, state = material_response(MaterialModels.∂Pᵀ∂F(), mat, F, state, Δt)
+    Pᵀ, dPᵀdF, state = material_response(MaterialModels.∂Pᵀ∂F, mat, F, state, Δt)
     @test Pᵀ == S⋅F'
 
-    S_E, dSdE, state = material_response(MaterialModels.∂S∂E(), mat, F, state, Δt)
+    S_E, dSdE, state = material_response(MaterialModels.∂S∂E, mat, F, state, Δt)
     @test S_E == S
     @test 2dSdC == dSdE
 

--- a/test/test_straintraits.jl
+++ b/test/test_straintraits.jl
@@ -46,4 +46,10 @@
     end
     dPᵀdF_autodiff = gradient(F->first_piola_kirchhoff_transposed(mat, F), F)
     @test dPᵀdF ≈ dPᵀdF_autodiff
+
+    # strain energy
+    @test elastic_strain_energy_density(mat, C) ==
+        elastic_strain_energy_density(mat, RightCauchyGreen(C)) ==
+        elastic_strain_energy_density(mat, GreenLagrange(E)) ==
+        elastic_strain_energy_density(mat, DeformationGradient(F))
 end 

--- a/test/test_stvenant.jl
+++ b/test/test_stvenant.jl
@@ -16,4 +16,8 @@
 
     dSdC_autodiff = gradient(C->material_response(m, C)[1], C)
     @test dSdC_autodiff ≈ dSdC
+
+    # stress/ strain measures
+    @test MaterialModels.native_strain_type(StVenant) == RightCauchyGreen
+    @test MaterialModels.native_stress_type(StVenant) == MaterialModels.SecondPiolaKirchhoff
 end

--- a/test/test_yeoh.jl
+++ b/test/test_yeoh.jl
@@ -22,4 +22,8 @@
 
     dSdC_autodiff = gradient(C->material_response(m, C)[1], C)
     @test isapprox(dSdC_autodiff, dSdC; rtol=1e-7)
+
+    # stress/ strain measures
+    @test MaterialModels.native_strain_type(Yeoh) == RightCauchyGreen
+    @test MaterialModels.native_stress_type(Yeoh) == MaterialModels.SecondPiolaKirchhoff
 end


### PR DESCRIPTION
This PR should in particular allow to call `material_response` with a specified strain measure while using the tangent transformation system. Before, the input strain measure had to be the deformation gradient (when using the tangent transformations).