### PR TITLE
Fix finite strain tangents to actually return dSdC instead of dSdE

### DIFF
--- a/src/FiniteStrain/neohook.jl
+++ b/src/FiniteStrain/neohook.jl
@@ -37,7 +37,7 @@ function material_response(mp::NeoHook, C::SymmetricTensor{2,3}, state::NeoHookS
     invC = inv(C)
     J = sqrt(det(C))
     S = mp.μ*(one(SymmetricTensor{2,3}) - inv(C)) + mp.λ*log(J)*inv(C)
-    ∂S∂C = mp.λ*(invC⊗invC) + 2*(mp.μ-mp.λ*log(J))*otimesu(invC,invC)
+    ∂S∂C = 0.5*(mp.λ*(invC⊗invC) + 2*(mp.μ-mp.λ*log(J))*otimesu(invC,invC))
     ∂S∂C = symmetric(∂S∂C)
     return S, ∂S∂C, NeoHookState()
 end

--- a/src/FiniteStrain/stvenant.jl
+++ b/src/FiniteStrain/stvenant.jl
@@ -41,7 +41,7 @@ function material_response(mp::StVenant, C::SymmetricTensor{2,3}, state::StVenan
     I = one(SymmetricTensor{2,3})
 
     S = λ/2 * (tr(C) - 3)*I + μ*(C-I)
-    ∂S∂C = λ*(I⊗I) + μ*(otimesu(I,I) + otimesl(I,I))
+    ∂S∂C = 0.5*(λ*(I⊗I) + μ*(otimesu(I,I) + otimesl(I,I)))
     ∂S∂C = symmetric(∂S∂C)
 
     return S, ∂S∂C, StVenantState()

--- a/src/FiniteStrain/yeoh.jl
+++ b/src/FiniteStrain/yeoh.jl
@@ -47,10 +47,9 @@ function material_response(mp::Yeoh, C::SymmetricTensor{2,3}, state::YeohState =
     Ic = tr(C)
 
     S = 2*(mp.μ/2*𝐈 + 2*mp.c₂*(Ic-3)*𝐈 + 3*mp.c₃*(Ic-3)^2*𝐈 - mp.μ*dlnJdc + mp.λ* log(J) * dlnJdc)
-    ∂S∂E = 4 * (2*mp.c₂*(𝐈 ⊗ 𝐈) + 6*mp.c₃*(Ic-3)*(𝐈 ⊗ 𝐈) - mp.μ*d2lnJdcdc + mp.λ*(log(J)*d2lnJdcdc + (dlnJdc ⊗ dlnJdc)))
-    ∂S∂E = symmetric(∂S∂E)
-    # TODO use transform tangents from traits branch
+    ∂S∂C = 4 * (2*mp.c₂*(𝐈 ⊗ 𝐈) + 6*mp.c₃*(Ic-3)*(𝐈 ⊗ 𝐈) - mp.μ*d2lnJdcdc + mp.λ*(log(J)*d2lnJdcdc + (dlnJdc ⊗ dlnJdc)))
+    ∂S∂C = symmetric(0.5∂S∂C)
 
-    return S, ∂S∂E, YeohState()
+    return S, ∂S∂C, YeohState()
 end
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -39,14 +39,8 @@ transform_tangent(S, dSdC, F::Tensor{2}, from::∂S∂C, to::∂S∂E) = S, 2dSd
 transform_tangent(S, dSdC, F::Tensor{2,3,T}, from::∂S∂C, to::∂Pᵀ∂F) where T = begin 
     I = one(SymmetricTensor{2,3,T})
     Pᵀ = S⋅F'
-    dPᵀdF = otimesu(F,I) ⊡ dSdC ⊡ otimesu(F',I) + otimesu(S,I)
+    dPᵀdF = otimesl(S, I) + otimesu(I, F) ⊡ dSdC ⊡ (otimesl(I, F') + otimesu(F', I))
     return Pᵀ, dPᵀdF
-end
-transform_tangent(Pᵀ, dPᵀdF, F::Tensor{2}, from::∂Pᵀ∂F, to::∂S∂C) = begin
-    I = one(SymmetricTensor{2,3,T})
-    S = Pᵀ ⋅ inv(F')
-    dSdC = 2 * inv( otimesu(F,I) ) ⊡ (dPᵀdF - otimesu(S,I)) ⊡ inv( otimesu(F',I) )
-    return S, dSdC
 end
 #...
 

--- a/test/test_neohook.jl
+++ b/test/test_neohook.jl
@@ -1,15 +1,24 @@
-
-
-function get_NeoHook_loading()
-    _C = range(0.0,  0.005, length=3)
-    C = [SymmetricTensor{2,3}((x +1.0, x/10, 0.0, 1.0, 0.0, 1.0)) for x in _C]
-    return C
-end  
-
 @testset "NeoHook" begin
-    m = NeoHook(μ=76.9, λ=115.0)
+    m = NeoHook(μ=1.0, λ=1.0)
 
-    loading = get_NeoHook_loading()
-    check_jld2(m, loading, "NeoHook")#, debug_print=false, OVERWRITE_JLD2=true)
-    check_tangents_AD(m,loading)
+    # correct strain energy
+    C = SymmetricTensor{2,3}((i,j)->i==j ? (i==1 ? exp(1.0) : 1.0) : 0.0) # det(C)=exp(1.0)
+    @test elastic_strain_energy_density(m, C) ≈ 0.5*(exp(1.0)-1.0) - 0.5 + 0.5*0.5^2
+
+    # correct stress + stress tangent
+    F = rand(Tensor{2,3})
+    C = tdot(F)
+    E = (C - one(C))/2
+
+    S, dSdC = material_response(m, C)
+    d²ΨdC², dΨdC = hessian(C->elastic_strain_energy_density(m, C), C, :all)
+    @test S ≈ 2dΨdC
+    @test dSdC ≈ 2d²ΨdC²
+
+    d²ΨdE², dΨdE = hessian(E->elastic_strain_energy_density(m, 2E + one(E)), E, :all)
+    @test 2dΨdC ≈ dΨdE
+    @test 4d²ΨdC²≈ d²ΨdE²
+
+    dSdC_autodiff = gradient(C->material_response(m, C)[1], C)
+    @test dSdC_autodiff ≈ dSdC
 end

--- a/test/test_straintraits.jl
+++ b/test/test_straintraits.jl
@@ -5,16 +5,32 @@
     F = Tensor{2,3}((2.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0))
     Δt = 0.0
     I = one(SymmetricTensor{2,3,Float64})
-
+    C = tdot(F)
+    E = (C - one(C))/2
 
     S, dSdC, state = material_response(MaterialModels.∂S∂C(), mat, F, state, Δt)
 
     Pᵀ, dPᵀdF, state = material_response(MaterialModels.∂Pᵀ∂F(), mat, F, state, Δt)
     @test Pᵀ == S⋅F'
-    @test dPᵀdF == otimesu(F,I) ⊡ dSdC ⊡ otimesu(F',I) + otimesu(S,I)
 
     S_E, dSdE, state = material_response(MaterialModels.∂S∂E(), mat, F, state, Δt)
     @test S_E == S
     @test 2dSdC == dSdE
 
+    function second_piola_kirchhoff_from_green_lagrange(mat, E)
+        C = 2E + one(E)
+        S, = material_response(mat, C)
+        return S
+    end
+    dSdE_autodiff = gradient(E->second_piola_kirchhoff_from_green_lagrange(mat, E), E)
+    @test dSdE ≈ dSdE_autodiff
+
+    function first_piola_kirchhoff_transposed(mat, F)
+        C = tdot(F)
+        S, = material_response(mat, C)
+        Pᵀ = S ⋅ F' 
+        return Pᵀ
+    end
+    dPᵀdF_autodiff = gradient(F->first_piola_kirchhoff_transposed(mat, F), F)
+    @test dPᵀdF ≈ dPᵀdF_autodiff
 end 

--- a/test/test_stvenant.jl
+++ b/test/test_stvenant.jl
@@ -1,14 +1,19 @@
-function get_StVenant_loading()
-    _C = range(0.0,  0.005, length=3)
-    C = [SymmetricTensor{2,3}((x + 1.0, x/10, 0.0, 1.0, 0.0, 1.0)) for x in _C]
-
-    return C
-end  
-
 @testset "StVenant" begin
-    m = StVenant(μ=6.8, λ=62.1)
+    m = StVenant(μ=1.0, λ=1.0)
 
-    loading = get_StVenant_loading()
-    check_jld2(m, loading, "StVenant")#, debug_print=false, OVERWRITE_JLD2=true)
-    check_tangents_AD(m,loading)
+    F = rand(Tensor{2,3})
+    C = tdot(F)
+    E = (C - one(C))/2
+
+    S, dSdC = material_response(m, C)
+    d²ΨdC², dΨdC = hessian(C->elastic_strain_energy_density(m, C), C, :all)
+    @test S ≈ 2dΨdC
+    @test dSdC ≈ 2d²ΨdC²
+
+    d²ΨdE², dΨdE = hessian(E->elastic_strain_energy_density(m, 2E + one(E)), E, :all)
+    @test 2dΨdC ≈ dΨdE
+    @test 4d²ΨdC²≈ d²ΨdE²
+
+    dSdC_autodiff = gradient(C->material_response(m, C)[1], C)
+    @test dSdC_autodiff ≈ dSdC
 end


### PR DESCRIPTION
- The finite strain elasticity routines returned `dSdE` instead of `dSdC`.
- Fix strain conversion wrapper for `dSdC`->`dPdF`
- Remove strain conversion wrapper for `dPdF`->`dSdC` (not correct, unclear when needed)