### PR TITLE
Stress iterations for sigma_33 = 0

### DIFF
--- a/src/MaterialModels.jl
+++ b/src/MaterialModels.jl
@@ -103,7 +103,7 @@ export elastic_strain_energy_density
 export AbstractMaterial, AbstractMaterialState
 export LinearElastic, TransverselyIsotropic, Plastic, CrystalViscoPlastic
 export LinearElasticState, TransverselyIsotropicState, PlasticState, CrystalViscoPlasticState
-export AbstractDim, UniaxialStrain, UniaxialStress, PlaneStrain, PlaneStress, ShellState
+export AbstractDim, UniaxialStrain, UniaxialStress, PlaneStrain, PlaneStress, ShellStress
 
 export DeformationGradient, RightCauchyGreen, GreenLagrange, SmallStrain
 export NeoHook, Yeoh, StVenant

--- a/src/MaterialModels.jl
+++ b/src/MaterialModels.jl
@@ -103,7 +103,7 @@ export elastic_strain_energy_density
 export AbstractMaterial, AbstractMaterialState
 export LinearElastic, TransverselyIsotropic, Plastic, CrystalViscoPlastic
 export LinearElasticState, TransverselyIsotropicState, PlasticState, CrystalViscoPlasticState
-export AbstractDim, UniaxialStrain, UniaxialStress, PlaneStrain, PlaneStress
+export AbstractDim, UniaxialStrain, UniaxialStress, PlaneStrain, PlaneStress, ShellState
 
 export DeformationGradient, RightCauchyGreen, GreenLagrange, SmallStrain
 export NeoHook, Yeoh, StVenant

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -5,21 +5,26 @@ struct UniaxialStrain{dim} <: AbstractDim{dim} end # 1D uniaxial strain state
 struct UniaxialStress{dim} <: AbstractDim{dim} end # 1D uniaxial stress state
 struct PlaneStrain{dim} <: AbstractDim{dim} end # 2D plane strain state
 struct PlaneStress{dim} <: AbstractDim{dim} end # 2D plane stress state
+struct ShellStress{dim} <: MaterialModels.AbstractDim{dim} end #σ33 == 0.0
+
 # constructors without dim parameter
 UniaxialStrain() = UniaxialStrain{1}()
 UniaxialStress() = UniaxialStress{1}()
 PlaneStrain() = PlaneStrain{2}()
 PlaneStress() = PlaneStress{2}()
+ShellStress() = ShellStress{3}()
 
 reduce_dim(A::Tensor{1,3}, ::AbstractDim{dim}) where dim = Tensor{1,dim}(i->A[i])
 reduce_dim(A::Tensor{2,3}, ::AbstractDim{dim}) where dim = Tensor{2,dim}((i,j)->A[i,j])
 reduce_dim(A::Tensor{4,3}, ::AbstractDim{dim}) where dim = Tensor{4,dim}((i,j,k,l)->A[i,j,k,l])
 reduce_dim(A::SymmetricTensor{2,3}, ::AbstractDim{dim}) where dim = SymmetricTensor{2,dim}((i,j)->A[i,j])
 reduce_dim(A::SymmetricTensor{4,3}, ::AbstractDim{dim}) where dim = SymmetricTensor{4,dim}((i,j,k,l)->A[i,j,k,l])
+reduce_dim(A::SymmetricTensor{4,3}, ::AbstractDim{3}) = A
 
 increase_dim(A::Tensor{1,dim,T}) where {dim, T} = Tensor{1,3}(i->(i <= dim ? A[i] : zero(T)))
 increase_dim(A::Tensor{2,dim,T}) where {dim, T} = Tensor{2,3}((i,j)->(i <= dim && j <= dim ? A[i,j] : zero(T)))
 increase_dim(A::SymmetricTensor{2,dim,T}) where {dim, T} = SymmetricTensor{2,3}((i,j)->(i <= dim && j <= dim ? A[i,j] : zero(T)))
+increase_dim(A::SymmetricTensor{2,3}) = A
 
 # restricted strain states
 function material_response(
@@ -114,6 +119,35 @@ function _frommandel_sarray(::UniaxialStress, A::SMatrix{1,1,T}) where T
     return frommandel(SymmetricTensor{4,1,T}, A)
 end
 
+# #
+# ShellStress
+# # 
+function _tomandel_sarray(::ShellStress, A::SymmetricTensor{2, 3}) 
+    @SVector [A[3,3],]
+end
+
+function _tomandel_sarray(::ShellStress, A::SymmetricTensor{4, 3}) 
+    @SMatrix [A[3,3,3,3],]
+end
+
+function _frommandel_sarray(::ShellStress, A::SVector{1,T}) where T 
+    return SymmetricTensor{2,3,T,6}( (0.0, 0.0, 0.0, 0.0, 0.0, A[1]) )
+end
+
+function _frommandel_sarray(::ShellStress, v::SMatrix{5,5,T}) where T 
+    #v is the stiffness tensor in voight format with stiffnesses associated with the third column and row == 0.0
+    #Convert it to tensor notation:
+    order = @SMatrix[1 5 4; 0 2 3; 0 0 0]
+    return SymmetricTensor{4,3,T}(function (i, j, k, l)
+            (i==3 && j==3) && return zero(T)
+            (k==3 && l==3) && return zero(T)
+            i > j && ((i, j) = (j, i))
+            k > l && ((k, l) = (l, k))
+            i == j && k == l ? (return v[order[i, j], order[k, l]]) :
+            i == j || k == l ? (return T(v[order[i, j], order[k, l]] / √2)) :
+                               (return T(v[order[i, j], order[k, l]] / (√2 * √2)))
+        end)
+end
 
 # out of plane / axis components for restricted stress cases
 get_zero_indices(::PlaneStress{2}, ::SymmetricTensor{2,3}) = @SVector[3, 4, 5] # for voigt/mandel format, do not use on tensor data!
@@ -126,43 +160,5 @@ get_nonzero_indices(::UniaxialStress{1}, ::SymmetricTensor{2,3}) = @SVector[1] #
 get_zero_indices(::UniaxialStress{1}, ::Tensor{2,3}) = @SVector[2,3,4,5,6,7,8,9] # for voigt/mandel format, do not use on tensor data!
 get_nonzero_indices(::UniaxialStress{1}, ::Tensor{2,3}) = @SVector[1] # for voigt/mandel format, do not use on tensor data!
 
-
-#wip:
-
-struct ShellState{dim} <: MaterialModels.AbstractDim{dim} end # 2D plane stress state
-# constructors without dim parameter
-ShellState() = ShellState{3}()
-
-function MaterialModels._tomandel_sarray(::ShellState, A::SymmetricTensor{2, 3}) 
-    @SVector [A[3,3],]
-end
-
-function MaterialModels._tomandel_sarray(::ShellState, A::SymmetricTensor{4, 3}) 
-    @SMatrix [A[3,3,3,3],]
-end
-
-function MaterialModels._frommandel_sarray(::ShellState, A::SVector{1,T}) where T 
-    return SymmetricTensor{2,3,T,6}( (0.0, 0.0, 0.0, 0.0, 0.0, A[1]) )
-end
-
-function MaterialModels._frommandel_sarray(::ShellState, v::SMatrix{5,5,T}) where T 
-    order = [1 5 4;
-             0 2 3;
-             0 0 0]
-    return SymmetricTensor{4,3,T}(function (i, j, k, l)
-            (i==3 && j==3) && return zero(T)
-            (k==3 && l==3) && return zero(T)
-            i > j && ((i, j) = (j, i))
-            k > l && ((k, l) = (l, k))
-            i == j && k == l ? (return v[order[i, j], order[k, l]]) :
-            i == j || k == l ? (return T(v[order[i, j], order[k, l]] / √2)) :
-                               (return T(v[order[i, j], order[k, l]] / (√2 * √2)))
-        end)
-end
-
-
-# out of plane / axis components for restricted stress cases
-MaterialModels.get_zero_indices(::ShellState{3}, ::SymmetricTensor{2,3}) = @SVector [3,]
-MaterialModels.get_nonzero_indices(::ShellState{3}, ::SymmetricTensor{2,3}) = @SVector [1, 2, 4, 5, 6]
-MaterialModels.reduce_dim(A::SymmetricTensor{4,3}, ::AbstractDim{3}) = A
-MaterialModels.increase_dim(A::SymmetricTensor{2,3}) = A
+get_zero_indices(::ShellStress{3}, ::SymmetricTensor{2,3}) = @SVector [3,]
+get_nonzero_indices(::ShellStress{3}, ::SymmetricTensor{2,3}) = @SVector [1, 2, 4, 5, 6]

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -45,7 +45,7 @@ end
 
 # restricted stress states
 function material_response(
-    dim::AbstractDim{d},#Union{UniaxialStress{d}, PlaneStress{d}},
+    dim::Union{UniaxialStress{d}, PlaneStress{d}, ShellStress{d}},
     m::AbstractMaterial,
     Δε::AbstractTensor{2,d,T},
     state::AbstractMaterialState,

--- a/test/test_wrappers.jl
+++ b/test/test_wrappers.jl
@@ -19,6 +19,22 @@
     @test σ ≈ ∂σ∂ε ⊡ Δε
     @test tovoigt(∂σ∂ε) ≈ m.E/(1-m.ν^2)*[1 m.ν 0; m.ν 1 0; 0 0 (1-m.ν)/2]
 
+    # Shell stress σ33 == 0.0
+    dim = ShellStress()
+    Δε = rand(SymmetricTensor{2,3})
+    σ, ∂σ∂ε, temp_state = material_response(dim, m, Δε, state)
+    ν = m.ν
+    a = (1-ν)/2
+    ∂σ∂ε_shell = m.E/(1-m.ν^2) * [1 ν 0 0 0 0; #From "The Finite Element Method - Linear static and dynamic FEM" by Thomas J.R Hughes
+                                  ν 1 0 0 0 0;
+                                  0 0 0 0 0 0
+                                  0 0 0 a 0 0;
+                                  0 0 0 0 a 0;
+                                  0 0 0 0 0 a]
+    @test σ[3,3] ≈ 0.0 atol=1e-10
+    @test σ ≈ ∂σ∂ε ⊡ Δε
+    @test tovoigt(∂σ∂ε) ≈ ∂σ∂ε_shell
+    
     ################################################
     # strain wrapper
     ################################################


### PR DESCRIPTION
In shell models, there is often a criteria that sigma_33 = 0. It was quite easy to add to the current framework.

Note that the stiffness components in the out-of-plane direction is set to zero.

Also change some vectors to static arrays to avoid allocations